### PR TITLE
fixed french word for island

### DIFF
--- a/attendees_and_learners.rst
+++ b/attendees_and_learners.rst
@@ -8,7 +8,7 @@ or followed the tutorial in their own time.
 Workshops
 =========
 
-DjangoCon Europe on L'îsle des Embiez, 16th May 2014
+DjangoCon Europe on L'île des Embiez, 16th May 2014
 ----------------------------------------------------
 
 


### PR DESCRIPTION
Ile can be written with or without `^` but does'nt take a `s` anymore.
